### PR TITLE
Add NOTICE.txt with copyright info

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,3 @@
+sauceproxy-rest
+
+Copyright 2016 Sauce Labs Inc


### PR DESCRIPTION
With an Apache 2.0 license, the recommended way is to add a separate file with information on the copyright holder.