### PR TITLE
SC-854 Close REST response body

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -184,8 +184,9 @@ func (c *Client) executeRequest(
 		return fmt.Errorf("couldn't connect to %s: %s", req.URL, err)
 	}
 
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
 		return fmt.Errorf(
 			"error querying from %s. HTTP status: %s",
 			req.URL,

--- a/rest.go
+++ b/rest.go
@@ -44,8 +44,8 @@ type Client struct {
 	Client http.Client
 
 	// Methods to override default functionality
-	DecodeJSON func(reader io.ReadCloser, v interface{}) error
-	EncodeJSON func(writer io.Writer, v interface{}) error
+	DecodeJSON  func(reader io.ReadCloser, v interface{}) error
+	EncodeJSON  func(writer io.Writer, v interface{}) error
 	LogFunction func(prefix string, msg string, logLevel int)
 }
 


### PR DESCRIPTION
When using http.Client, the caller is expected to close the response. See https://golang.org/pkg/net/http/ for more information.

@saucelabs/connected-cloud 