### PR TITLE
[SC-859]

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -185,9 +185,13 @@ func (c *Client) executeRequest(
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		// there could be an error here in json format
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(resp.Body)
 		return fmt.Errorf(
-			"error querying from %s. HTTP status: %s",
+			"error querying from %s, error was: %s. HTTP status: %s",
 			req.URL,
+			buf.String(),
 			resp.Status)
 	}
 


### PR DESCRIPTION
When we decode json from the response body, we only parse out fields based on the `v interface{}` object we pass in, and therefore won't get `{error: 'too many tunnels' } when the user requests a new tunnel but are at their ccy limit. We need,parse potential JSON error from response body.

cc: @saucelabs/connected-cloud