### PR TITLE
[SC-859] add test for missing error logging in default error case

### DIFF
--- a/rest_test.go
+++ b/rest_test.go
@@ -508,6 +508,21 @@ func TestClientCreateWaitError(t *testing.T) {
 	}
 }
 
+func TestClientErrorMessage(t *testing.T) {
+	var server = multiResponseServer([]R{
+		errorResponse(400, `{"error": "Too many active org tunnels: N+1 >= N"}`),
+	})
+	defer server.Close()
+
+	_, err := createTunnel(server.URL)
+	if err == nil {
+		t.Errorf("client.createWithTimeout didn't error")
+	}
+	if !(strings.Contains(err.Error(), "Too many active org tunnels")) {
+		t.Errorf("Invalid error: %s, did not contain json message with error.", err.Error())
+	}
+}
+
 func TestTunnelHeartBeat(t *testing.T) {
 	var server = multiResponseServer([]R{
 		stringResponse(createJSON),


### PR DESCRIPTION
@saucelabs/connected-cloud

the previous tests only checked for parsing out messages in string responses in non-error cases, we need to ensure we get the info out in error cases