### PR TITLE
SC-879 fix overlapping tunnel detection with named tunnels

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -42,8 +42,8 @@ type Client struct {
 	Password string
 
 	// Methods to override default functionality
-	DecodeJSON  func(reader io.ReadCloser, v interface{}) error
-	EncodeJSON  func(writer io.Writer, v interface{}) error
+	DecodeJSON func(reader io.ReadCloser, v interface{}) error
+	EncodeJSON func(writer io.Writer, v interface{}) error
 	// Execute the request, http.DefaultClient.Do by default
 	ExecuteRequest func(*http.Request) (*http.Response, error)
 }
@@ -258,12 +258,13 @@ func (c *Client) Find(name string, domains []string) (
 	}
 
 	for _, state := range list {
-		if name != "" && state.TunnelIdentifier == name {
-			matches = append(matches, state.Id)
-			continue
-		}
-
-		if checkOverlappingDomains(domains, state.DomainNames) {
+		// Don't remove any other named tunnel, or a non-named tunnel if we are
+		// a named tunnel.
+		if name == "" {
+			if checkOverlappingDomains(domains, state.DomainNames) {
+				matches = append(matches, state.Id)
+			}
+		} else if state.TunnelIdentifier == name {
 			matches = append(matches, state.Id)
 		}
 	}

--- a/rest.go
+++ b/rest.go
@@ -259,7 +259,7 @@ func (c *Client) Find(name string, domains []string) (
 
 	for _, state := range list {
 		// If we're an unamed tunnel, check the overlapping domain names
-		if name == "" {
+		if name == "" && state.TunnelIdentifier == "" {
 			if checkOverlappingDomains(domains, state.DomainNames) {
 				matches = append(matches, state.Id)
 			}

--- a/rest_test.go
+++ b/rest_test.go
@@ -204,13 +204,23 @@ func TestClientFindUnamed(t *testing.T) {
 	if !reflect.DeepEqual(matches, []string{"fakeid"}) {
 		t.Errorf("client.Find returned %+v\n", matches)
 	}
+
+	matches, err = findMatchingTunnel(listTunnelJSON, "", []string{"other.domain"})
+
+	if err != nil {
+		t.Errorf("client.Find errored %+v\n", err)
+	}
+
+	if matches != nil {
+		t.Errorf("client.Find returned %+v\n", matches)
+	}
 }
 
 // A named tunnel should only return tunnels with the same name, and ignore
 // the overlapping domains.
 func TestClientFindNamed(t *testing.T) {
 	var matches, err = findMatchingTunnel(
-		listTunnelJSON, "myname", []string{"sauce-connect.proxy"})
+		listTunnelJSON, "badname", []string{"sauce-connect.proxy"})
 
 	if err != nil {
 		t.Errorf("client.Find errored %+v\n", err)
@@ -218,6 +228,18 @@ func TestClientFindNamed(t *testing.T) {
 
 	// Make sure we got an empty array
 	if matches != nil {
+		t.Errorf("client.Find returned %+v\n", matches)
+	}
+
+	// check name matching ignores domain
+	matches, err = findMatchingTunnel(
+		listTunnelJSON, "fakename", []string{"other.domain"})
+
+	if err != nil {
+		t.Errorf("client.Find errored %+v\n", err)
+	}
+
+	if !reflect.DeepEqual(matches, []string{"fakeid"}) {
 		t.Errorf("client.Find returned %+v\n", matches)
 	}
 }

--- a/rest_test.go
+++ b/rest_test.go
@@ -195,7 +195,9 @@ const listTunnelJSON = `[
 
 // An unamed tunnel must match the tunnels with overlapping domain names.
 func TestClientFindUnamed(t *testing.T) {
-	var matches, err = findMatchingTunnel(listTunnelJSON, "", []string{"sauce-connect.proxy"})
+	var matches, err = findMatchingTunnel(
+		`[{"domain_names": ["test1"], "tunnel_identifier": null, "id": "fakeid"}]`,
+		"", []string{"test1"})
 
 	if err != nil {
 		t.Errorf("client.Find errored %+v\n", err)
@@ -205,13 +207,29 @@ func TestClientFindUnamed(t *testing.T) {
 		t.Errorf("client.Find returned %+v\n", matches)
 	}
 
-	matches, err = findMatchingTunnel(listTunnelJSON, "", []string{"other.domain"})
+	// 2 empty names, no overlapping domain -> no match
+	matches, err = findMatchingTunnel(
+		`[{"domain_names": ["test1"], "tunnel_identifier": null, "id": "fakeid"}]`,
+		"", []string{"other.domain"})
 
 	if err != nil {
 		t.Errorf("client.Find errored %+v\n", err)
 	}
 
 	if matches != nil {
+		t.Errorf("client.Find returned %+v\n", matches)
+	}
+
+	// 2 empty names, overlapping domain -> match
+	matches, err = findMatchingTunnel(
+		`[{"domain_names": ["test1"], "tunnel_identifier": null, "id": "fakeid"}]`,
+		"", []string{"test1"})
+
+	if err != nil {
+		t.Errorf("client.Find errored %+v\n", err)
+	}
+
+	if !reflect.DeepEqual(matches, []string{"fakeid"}) {
 		t.Errorf("client.Find returned %+v\n", matches)
 	}
 }


### PR DESCRIPTION
The old overlapping tunnel logic would skip overlapping domains detection when the tunnel had a name:

https://github.com/saucelabs/libsauceconnect/blob/sc-4.4.3/sauceconnect/sc_client.c#L220-L225

This fixes the client.Find() method to do the same thing.

Added an extra-test to make sure we don't get a regression for this in the future.

I also editing the JSON document strings in the tests so it's not super verbose.

See https://saucedev.atlassian.net/browse/SC-879

@saucelabs/connected-cloud 