### PR TITLE
SC-1006 always get versions from saucelabs.com

### DIFF
--- a/cmd/sauceproxy_ctl/main.go
+++ b/cmd/sauceproxy_ctl/main.go
@@ -37,7 +37,7 @@ type CreateOptions struct {
 	SharedTunnel     bool          `short:"s" long:"shared-tunnel" description:"Let sub-accounts of the tunnel owner use the tunnel if requested."`
 	VmVersion        string        `long:"vm-version" value-name:"<version>" description:"Request a specific tunnel VM version."`
 	NoSslBumpDomains []string      `short:"B" long:"no-ssl-bump-domains" value-name:"<...>" description:"Comma-separated list of domains. Requests whose host matches one of these will not be SSL re-encrypted."`
-	ExtraInfo		 string        `long:"extra-info" description:"JSON document to with extra feature flags"`
+	ExtraInfo        string        `long:"extra-info" description:"JSON document to with extra feature flags"`
 	Timeout          time.Duration `long:"timeout" description:"Timeout (example: 10, 10s 1m, or 1h)"`
 }
 
@@ -92,12 +92,12 @@ type Options struct {
 			Id string `description:"Tunnel ID (not tunnel identifier)"`
 		} `positional-args:"yes" required:"yes"`
 	} `command:"status"`
-	Find TunnelOptions `command:"find"`
-	List struct{}      `command:"list"`
-	Ping PingOptions   `command:"ping"`
+	Find      TunnelOptions `command:"find"`
+	List      struct{}      `command:"list"`
+	Ping      PingOptions   `command:"ping"`
 	Keepalive struct {
 		PingOptions
-		Period	time.Duration `short:"p" description:"period between keepalive" default:"30s"`
+		Period time.Duration `short:"p" description:"period between keepalive" default:"30s"`
 	} `command:"keepalive"`
 	KgpHost struct {
 		Arg struct {
@@ -154,7 +154,7 @@ func main() {
 	}
 	switch command {
 	case "checkversion":
-		build, u, err := client.GetLastVersion()
+		build, u, err := client.GetLastVersion("")
 		if err == nil {
 			fmt.Printf("%d %s\n", build, u)
 		} else {
@@ -184,7 +184,7 @@ func main() {
 				SharedTunnel:     options.SharedTunnel,
 				VMVersion:        options.VmVersion,
 				NoSSLBumpDomains: options.NoSslBumpDomains,
-				ExtraInfo:		  options.ExtraInfo,
+				ExtraInfo:        options.ExtraInfo,
 				Metadata:         metadata,
 			},
 			timeout,
@@ -248,10 +248,10 @@ func main() {
 		}
 	case "kgp_host":
 		var id = o.KgpHost.Arg.Id
-		if host, err := client.KgpHost(id); err != nil {
+		if host, hostIp, err := client.KgpHost(id); err != nil {
 			log.Fatalln(err)
 		} else {
-			fmt.Println(host)
+			fmt.Printf("KGP server hostname: %s, ip address: %s", host, hostIp)
 		}
 	default:
 		logger.Fatalln("unknown command:", command)

--- a/cmd/sauceproxy_ctl/main.go
+++ b/cmd/sauceproxy_ctl/main.go
@@ -154,7 +154,7 @@ func main() {
 	}
 	switch command {
 	case "checkversion":
-		build, u, err := client.GetLastVersion("")
+		build, u, err := client.GetLastVersion()
 		if err == nil {
 			fmt.Printf("%d %s\n", build, u)
 		} else {

--- a/rest.go
+++ b/rest.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+const SauceLabsURL = "https://saucelabs.com"
+
 //
 // Decode `reader` into the object `v`, and close `reader` after.
 //
@@ -54,11 +56,13 @@ type Client struct {
 // Return the newest build number for the platform as determined by
 // runtime.GOOS, and the URL to download the latest verion.
 //
-func (c *Client) GetLastVersion() (
+func (c *Client) GetLastVersion(versionUrl string) (
 	build int, downloadUrl string, err error,
 ) {
-	// We use only the hostname part of base url
-	u, err := url.Parse(c.BaseURL)
+	if versionUrl == "" {
+		versionUrl = SauceLabsURL
+	}
+	u, err := url.Parse(versionUrl)
 	u.Path = ""
 	var fullUrl = fmt.Sprintf("%s/versions.json", u)
 
@@ -551,13 +555,13 @@ func (c *Client) Status(id string) (
 	return
 }
 
-func (c *Client) KgpHost(id string) (string, error) {
+func (c *Client) KgpHost(id string) (string, string, error) {
 	var s, err = c.status(id)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	return s.Host, nil
+	return s.Host, s.Ip, nil
 }
 
 func (t *Tunnel) Status() (

--- a/rest.go
+++ b/rest.go
@@ -56,12 +56,16 @@ type Client struct {
 // Return the newest build number for the platform as determined by
 // runtime.GOOS, and the URL to download the latest verion.
 //
-func (c *Client) GetLastVersion(versionUrl string) (
+
+func (c *Client) GetLastVersion() (
 	build int, downloadUrl string, err error,
 ) {
-	if versionUrl == "" {
-		versionUrl = SauceLabsURL
-	}
+	return c.GetLastVersionFromURL(SauceLabsURL)
+}
+
+func (c *Client) GetLastVersionFromURL(versionUrl string) (
+	build int, downloadUrl string, err error,
+) {
 	u, err := url.Parse(versionUrl)
 	u.Path = ""
 	var fullUrl = fmt.Sprintf("%s/versions.json", u)

--- a/rest_test.go
+++ b/rest_test.go
@@ -97,7 +97,7 @@ func TestGetLastVersion(t *testing.T) {
 	var client = Client{
 		BaseURL: server.URL,
 	}
-	build, url, err := client.GetLastVersion(server.URL)
+	build, url, err := client.GetLastVersionFromURL(server.URL)
 
 	if err != nil {
 		t.Errorf("%v", err)
@@ -119,7 +119,7 @@ func TestGetLastVersionBadJSON(t *testing.T) {
 	var client = Client{
 		BaseURL: server.URL,
 	}
-	_, _, err := client.GetLastVersion(server.URL)
+	_, _, err := client.GetLastVersionFromURL(server.URL)
 
 	if err == nil {
 		t.Error("GetLastVersion == nil")
@@ -139,7 +139,7 @@ func TestGetLastVersion404(t *testing.T) {
 	var client = Client{
 		BaseURL: server.URL,
 	}
-	_, _, err := client.GetLastVersion(server.URL)
+	_, _, err := client.GetLastVersionFromURL(server.URL)
 
 	if err == nil {
 		t.Error("GetLastVersion == nil")
@@ -159,7 +159,7 @@ func TestGetLastVersionNoServer(t *testing.T) {
 	var client = Client{
 		BaseURL: server.URL,
 	}
-	_, _, err := client.GetLastVersion(server.URL)
+	_, _, err := client.GetLastVersionFromURL(server.URL)
 
 	if err == nil {
 		t.Error("GetLastVersion == nil")

--- a/rest_test.go
+++ b/rest_test.go
@@ -97,7 +97,7 @@ func TestGetLastVersion(t *testing.T) {
 	var client = Client{
 		BaseURL: server.URL,
 	}
-	build, url, err := client.GetLastVersion()
+	build, url, err := client.GetLastVersion(server.URL)
 
 	if err != nil {
 		t.Errorf("%v", err)
@@ -119,7 +119,7 @@ func TestGetLastVersionBadJSON(t *testing.T) {
 	var client = Client{
 		BaseURL: server.URL,
 	}
-	_, _, err := client.GetLastVersion()
+	_, _, err := client.GetLastVersion(server.URL)
 
 	if err == nil {
 		t.Error("GetLastVersion == nil")
@@ -139,7 +139,7 @@ func TestGetLastVersion404(t *testing.T) {
 	var client = Client{
 		BaseURL: server.URL,
 	}
-	_, _, err := client.GetLastVersion()
+	_, _, err := client.GetLastVersion(server.URL)
 
 	if err == nil {
 		t.Error("GetLastVersion == nil")
@@ -159,7 +159,7 @@ func TestGetLastVersionNoServer(t *testing.T) {
 	var client = Client{
 		BaseURL: server.URL,
 	}
-	_, _, err := client.GetLastVersion()
+	_, _, err := client.GetLastVersion(server.URL)
 
 	if err == nil {
 		t.Error("GetLastVersion == nil")


### PR DESCRIPTION
`GetLastVersion()` will always use default URL to get json with SC versions. Added `GetLastVersionFromURL` that can be used for testing and/or custom endpoint

### Note
Also modified `client.KgpHost`. It's only used by rest_ctl tool, it could be useful to get info about tunnel VM.